### PR TITLE
problem about rotate through modelmatrix

### DIFF
--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -1127,7 +1127,7 @@ define([
         // but may be transformed by additional transforms applied in Cesium.
         // This is why the transform is calculated as the difference between the initial transform and the current transform.
         transform = Matrix4.multiplyTransformation(transform, Matrix4.inverseTransformation(initialTransform, scratchTransform), scratchTransform);
-        center = Matrix4.multiplyByPoint(transform, center, center);
+        //center = Matrix4.multiplyByPoint(transform, center, center);
         var rotationScale = Matrix4.getRotation(transform, scratchMatrix);
         halfAxes = Matrix3.multiply(rotationScale, halfAxes, halfAxes);
 


### PR DESCRIPTION
when i rotate 3dTiles through set modelmatrix ，the 3dTiles will disappear
in the tileset,json,type of boundingVolume  is region
  "root": {
    "boundingVolume": {
      "region": [
        -1.3197209591796106,
        0.6988424218,
        -1.3196390408203893,
        0.6989055782,
        0,
        88
      ]
    },

in the function createBoxFromTransformedRegion, if use "center = Matrix4.multiplyByPoint(transform, center, center);",the 3dtile will rotate around the center of the earth